### PR TITLE
test(airdrop, non-membership-proofs): add unit tests for M1 acceptae criteria

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "rayon",
  "rs_merkle",
  "sapling-crypto",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tonic",

--- a/crates/non-membership-proofs/Cargo.toml
+++ b/crates/non-membership-proofs/Cargo.toml
@@ -33,6 +33,9 @@ zcash_primitives = { workspace = true }
 zcash_protocol = { workspace = true }
 zip32 = "0.2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
Add comprehensive unit tests to validate Milestone 1 acceptance criteria:

non-membership-proofs crate (14 tests):
- build_merkle_tree: empty, single, multiple nullifiers, sorting, determinism
- build_leaf: concatenation, determinism, order sensitivity
- file I/O: roundtrip read/write, empty files, error handling

airdrop crate (8 tests):
- is_sanitize: duplicate detection, sorting validation, nullifier arrays

These tests ensure:
- Nullifier derivation is deterministic
- Duplicate nullifiers are properly detected
- File parsing and validation work correctly

