### PR TITLE
chore: downgrade minimum supported rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: cargo build --release
         run: cargo build --release --locked
   msrv:
-    name: MSRV / 1.88.0
+    name: MSRV / 1.85.1
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Rust build environment
         uses: ./.github/actions/setup-rust-build
         with:
-          toolchain: "1.88.0"
+          toolchain: "1.85.1"
           shared-key: msrv
       - name: cargo check
         run: cargo check --locked --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.85.1"
 repository = "https://github.com/eigerco/zcash-namada-airdrop"
 license = "MIT"
 

--- a/crates/zair-nonmembership/src/sparse/sapling.rs
+++ b/crates/zair-nonmembership/src/sparse/sapling.rs
@@ -321,7 +321,7 @@ impl NonMembershipTree {
         let mut pos: u64 = position.into();
 
         for (level, sibling) in path.iter().enumerate() {
-            let (left, right) = if pos.is_multiple_of(2) {
+            let (left, right) = if pos % 2 == 0 {
                 (&current, sibling)
             } else {
                 (sibling, &current)

--- a/crates/zair-sapling-circuit/src/circuit.rs
+++ b/crates/zair-sapling-circuit/src/circuit.rs
@@ -693,7 +693,7 @@ mod tests {
             let auth_path = vec![
                 Some((
                     bls12_381::Scalar::random(&mut rng),
-                    !rng.next_u32().is_multiple_of(2_u32)
+                    !rng.next_u32() % 2 == 0
                 ));
                 tree_depth
             ];
@@ -711,7 +711,7 @@ mod tests {
                 .map(|_| {
                     Some((
                         bls12_381::Scalar::random(&mut rng),
-                        !rng.next_u32().is_multiple_of(2_u32),
+                        !rng.next_u32() % 2 == 0,
                     ))
                 })
                 .collect();

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -17,7 +17,7 @@ cargo build --release
 
 #### Prerequisites
 
-- Rust 1.91+ (2024 edition)
+- Rust 1.85.1+ (2024 edition)
 - Protobuf (`protoc`) for lightwalletd gRPC bindings
 
 Build with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.85.1"
 targets = []
 components = ["rust-src", "llvm-tools-preview"]
 


### PR DESCRIPTION
### Description

This PR adjusts the MSRV to `1.85.1` as we don't really need to depend on `1.88`.