### PR TITLE
chore: adjust public api

### DIFF
--- a/crates/zair-sapling-proofs/src/types.rs
+++ b/crates/zair-sapling-proofs/src/types.rs
@@ -39,6 +39,7 @@ impl From<zair_core::schema::config::ValueCommitmentScheme> for ValueCommitmentS
 /// The caller generates witness randomness (`alpha`, `rcv`, `rcv_sha256`) before calling
 /// the prover. The prover deterministically computes derived public values (`rk`, `cv`,
 /// `cv_sha256`) for inclusion in the proof output.
+#[cfg(feature = "prove")]
 #[derive(Debug, Clone)]
 pub struct ClaimProofInputs {
     /// Diversifier (11 bytes)

--- a/crates/zair-sapling-proofs/src/verifier/mod.rs
+++ b/crates/zair-sapling-proofs/src/verifier/mod.rs
@@ -4,6 +4,7 @@
 
 use bellman::gadgets::multipack;
 use bellman::groth16::{PreparedVerifyingKey, Proof, verify_proof};
+pub use bellman::groth16::{VerifyingKey, prepare_verifying_key};
 use bls12_381::Bls12;
 
 pub use crate::error::ClaimProofError;


### PR DESCRIPTION
### Changes

- Re-exports `bellman::groth16` verifying key utilities.
- Fixes a dead code warning when compiling with `verify`.