### PR TITLE
doc: clean up leftover patching sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ See the [Introduction](https://eigerco.github.io/zair/introduction.html) for mor
 
 ## Crates
 
-| Crate | Description |
-| --- | --- |
-| `zair-cli` | Primary `zair` CLI binary tool |
-| `zair-sdk` | The SDK and entrypoint for `zair` airdrops, used by the CLI |
-| `zair-core` | Core crate with shared types, config and schemas |
-| `zair-nonmembership` | Non-membership Merkle-tree primitive |
-| `zair-scan` | Lightwalletd gRPC client and chain scanning |
-| `zair-sapling-proofs` | Sapling proving and verification |
-| `zair-sapling-circuit` | Sapling claim circuit (Bellman/Groth16) |
-| `zair-orchard-proofs` | Orchard proving and verification |
-| `zair-orchard-circuit` | Orchard claim circuit (Halo2) |
+| Crate                  | Description                                                 |
+| ---------------------- | ----------------------------------------------------------- |
+| `zair-cli`             | Primary `zair` CLI binary tool                              |
+| `zair-sdk`             | The SDK and entrypoint for `zair` airdrops, used by the CLI |
+| `zair-core`            | Core crate with shared types, config and schemas            |
+| `zair-nonmembership`   | Non-membership Merkle-tree primitive                        |
+| `zair-scan`            | Lightwalletd gRPC client and chain scanning                 |
+| `zair-sapling-proofs`  | Sapling proving and verification                            |
+| `zair-sapling-circuit` | Sapling claim circuit (Bellman/Groth16)                     |
+| `zair-orchard-proofs`  | Orchard proving and verification                            |
+| `zair-orchard-circuit` | Orchard claim circuit (Halo2)                               |
 
 ## Getting started
 

--- a/docs/src/airdrop-proofs/index.md
+++ b/docs/src/airdrop-proofs/index.md
@@ -27,11 +27,11 @@ Outside the circuit:
 
 Each pool has two crates and one or more patched upstream dependencies:
 
-|                   | Sapling                   | Orchard                                          |
-| ----------------- | ------------------------- | ------------------------------------------------ |
-| Circuit           | `zair-sapling-circuit`    | `zair-orchard-circuit`                           |
-| Prover / verifier | `zair-sapling-proofs`     | `zair-orchard-proofs`                            |
-| Patched deps      | `.patched-sapling-crypto` | `.patched-orchard`, `.patched-halo2-gadgets`     |
+|                   | Sapling                | Orchard                    |
+| ----------------- | ---------------------- | -------------------------- |
+| Circuit           | `zair-sapling-circuit` | `zair-orchard-circuit`     |
+| Prover / verifier | `zair-sapling-proofs`  | `zair-orchard-proofs`      |
+| Patched deps      | `sapling-crypto`       | `orchard`, `halo2-gadgets` |
 
 The patches expose internal APIs (nullifier derivation with configurable domain, Pedersen/Sinsemilla
 hash internals, key types) so that host-side code can compute the same airdrop nullifiers and

--- a/docs/src/airdrop-proofs/orchard.md
+++ b/docs/src/airdrop-proofs/orchard.md
@@ -9,8 +9,8 @@ Implementation:
 
 Patched dependencies:
 
-- `.patched-orchard/` via `nix/airdrop-orchard-nullifier.patch`
-- `.patched-halo2-gadgets/` via `nix/airdrop-halo2-gadgets-sha256.patch`
+- `orchard/` from [https://github.com/eigerco/orchard](/url)
+- `halo2-gadgets/` from [https://github.com/eigerco/halo2](/url)
 
 ## Proof statement
 

--- a/docs/src/airdrop-proofs/sapling.md
+++ b/docs/src/airdrop-proofs/sapling.md
@@ -9,7 +9,7 @@ Implementation:
 
 Patched dependency:
 
-- `.patched-sapling-crypto/` via `nix/airdrop-sapling-nullifier.patch`
+- `sapling-crypto/` from [https://github.com/eigerco/sapling-crypto](/url)
 
 ## Proof statement
 


### PR DESCRIPTION
### Changes

- Formats docs.
- Replaces references to old patching method with new one and links to them.