### PR TITLE
feat(sdk): in-memory api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -117,9 +117,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
 dependencies = [
  "anstyle",
  "bstr",
@@ -155,9 +155,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -537,24 +537,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console-api"
@@ -871,12 +871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "equihash"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,9 +1009,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1030,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1040,15 +1034,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1057,15 +1051,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1074,21 +1068,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1097,9 +1091,9 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "libc",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1132,8 +1126,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1534,6 +1541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1640,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1672,10 +1685,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -1685,19 +1704,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1744,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memuse"
@@ -1864,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1969,18 +1987,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1989,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2036,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -2047,15 +2065,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2155,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2167,6 +2185,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -2349,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -2408,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2421,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2458,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2508,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2590,9 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2603,13 +2627,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2667,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2686,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2740,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e95dcd06bc1bb3f86ed9db1e1832a70125f32daae071ef37dcb7701b7d4fe"
+checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
 dependencies = [
  "bitflags",
  "either",
@@ -2758,9 +2788,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sinsemilla"
@@ -2787,12 +2817,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2827,9 +2857,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2861,12 +2891,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2970,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2985,9 +3015,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -3001,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3047,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -3079,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3091,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -3102,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3192,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3234,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -3246,6 +3276,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -3265,9 +3301,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.4"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -3279,15 +3315,15 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -3308,10 +3344,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3382,10 +3418,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3396,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3406,9 +3451,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3419,11 +3464,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -3437,13 +3516,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -3511,7 +3588,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3520,16 +3597,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3547,31 +3615,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3581,22 +3632,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3605,22 +3644,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3629,22 +3656,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3653,34 +3668,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3732,7 +3811,6 @@ dependencies = [
  "dotenvy",
  "eyre",
  "hex",
- "rustls",
  "serde_json",
  "tempfile",
  "tokio",
@@ -3845,7 +3923,7 @@ dependencies = [
  "blake2s_simd",
  "bytemuck",
  "ff",
- "futures 0.3.31",
+ "futures 0.3.32",
  "group",
  "hex",
  "http",
@@ -3889,6 +3967,7 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "rpassword",
+ "rustls",
  "sapling-crypto",
  "secrecy 0.10.3",
  "serde",
@@ -3926,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493217c813ba1f7ef4e6b6bf846f4e4cd57b6a070d679c9f15d2477e12d1464"
+checksum = "d2b5eca509a516dbd9e4d13c1f5befd6d9fa25c7e62460444ef1b3f62122f323"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -4079,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bed6cf5b2b4361105d4ea06b2752f0c8af4641756c7fbc9858a80af186c234f"
+checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
 dependencies = [
  "bip32",
  "bitflags",
@@ -4131,18 +4210,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4251,6 +4330,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/zair-cli/Cargo.toml
+++ b/crates/zair-cli/Cargo.toml
@@ -19,7 +19,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 dotenvy = { workspace = true }
 eyre = { workspace = true }
-rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = [
   "rt-multi-thread",
   "macros",

--- a/crates/zair-cli/src/main.rs
+++ b/crates/zair-cli/src/main.rs
@@ -49,9 +49,7 @@ fn init_tracing() -> eyre::Result<()> {
 )]
 async fn main() -> eyre::Result<()> {
     // Initialize rustls crypto provider (required for TLS connections)
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .map_err(|e| eyre::eyre!("Failed to install rustls crypto provider: {e:?}"))?;
+    zair_sdk::install_default_crypto_provider()?;
 
     // Load .env file (fails silently if not found)
     let _ = dotenvy::dotenv();

--- a/crates/zair-nonmembership/src/pool/sapling.rs
+++ b/crates/zair-nonmembership/src/pool/sapling.rs
@@ -25,7 +25,7 @@ pub fn map_sapling_user_positions(
 
 /// # Errors
 /// Returns an error if `gap_idx` is out of bounds for the given nullifiers.
-pub fn sapling_gap_bounds(
+pub const fn sapling_gap_bounds(
     nullifiers: &[Nullifier],
     gap_idx: usize,
 ) -> Result<(Nullifier, Nullifier), MerklePathError> {

--- a/crates/zair-nonmembership/src/sparse/sapling.rs
+++ b/crates/zair-nonmembership/src/sparse/sapling.rs
@@ -465,7 +465,7 @@ mod tests {
         }};
     }
 
-    fn make_leaf(value: u8) -> NonMembershipNode {
+    const fn make_leaf(value: u8) -> NonMembershipNode {
         let mut bytes = [0u8; 32];
         bytes[0] = value;
         NonMembershipNode::new(bytes)

--- a/crates/zair-orchard-proofs/src/instance.rs
+++ b/crates/zair-orchard-proofs/src/instance.rs
@@ -12,22 +12,19 @@ const NATIVE_INSTANCE_COUNT: usize = 7;
 /// Number of public instance scalars for the SHA-256 value commitment scheme.
 const SHA256_INSTANCE_COUNT: usize = 13;
 
-pub(crate) fn base_from_repr(bytes: [u8; 32]) -> Result<pallas::Base, ClaimProofError> {
+pub fn base_from_repr(bytes: [u8; 32]) -> Result<pallas::Base, ClaimProofError> {
     Option::<pallas::Base>::from(pallas::Base::from_repr(bytes))
         .ok_or(ClaimProofError::NonCanonicalBase)
 }
 
 #[cfg(feature = "prove")]
-pub(crate) fn scalar_from_repr(bytes: [u8; 32]) -> Result<pallas::Scalar, ClaimProofError> {
+pub fn scalar_from_repr(bytes: [u8; 32]) -> Result<pallas::Scalar, ClaimProofError> {
     Option::<pallas::Scalar>::from(pallas::Scalar::from_repr(bytes))
         .ok_or(ClaimProofError::NonCanonicalScalar)
 }
 
 #[cfg(feature = "prove")]
-pub(crate) fn target_id_slice(
-    target_id: &[u8; 32],
-    target_id_len: u8,
-) -> Result<&[u8], ClaimProofError> {
+pub fn target_id_slice(target_id: &[u8; 32], target_id_len: u8) -> Result<&[u8], ClaimProofError> {
     let target = target_id
         .get(..usize::from(target_id_len))
         .ok_or(ClaimProofError::InvalidTargetIdLength)?;
@@ -36,7 +33,7 @@ pub(crate) fn target_id_slice(
 }
 
 #[cfg(feature = "prove")]
-pub(crate) fn point_from_bytes(bytes: [u8; 32]) -> Result<pallas::Affine, ClaimProofError> {
+pub fn point_from_bytes(bytes: [u8; 32]) -> Result<pallas::Affine, ClaimProofError> {
     let p = Option::<pallas::Point>::from(pallas::Point::from_bytes(&bytes))
         .ok_or(ClaimProofError::InvalidPoint)?;
     if bool::from(p.is_identity()) {
@@ -57,7 +54,7 @@ fn coords_or_zero(p: pallas::Point) -> (pallas::Base, pallas::Base) {
     }
 }
 
-pub(crate) fn to_instance(
+pub fn to_instance(
     note_commitment_root: [u8; 32],
     cv: Option<[u8; 32]>,
     cv_sha256: Option<[u8; 32]>,

--- a/crates/zair-orchard-proofs/src/keys.rs
+++ b/crates/zair-orchard-proofs/src/keys.rs
@@ -13,7 +13,7 @@ use crate::error::ClaimProofError;
 use crate::types::ValueCommitmentScheme;
 
 #[derive(Debug)]
-pub(crate) struct Keys {
+pub struct Keys {
     pub(crate) vk: VerifyingKey<vesta::Affine>,
     #[cfg_attr(feature = "verify", allow(dead_code))]
     pub(crate) pk: plonk::ProvingKey<vesta::Affine>,
@@ -51,7 +51,7 @@ struct CacheKey {
     target_id_len: u8,
 }
 
-pub(crate) fn keys_for(
+pub fn keys_for(
     params: &Params<vesta::Affine>,
     scheme: ValueCommitmentScheme,
     target_id: [u8; 32],

--- a/crates/zair-sapling-proofs/src/prover/builder.rs
+++ b/crates/zair-sapling-proofs/src/prover/builder.rs
@@ -121,3 +121,23 @@ pub fn load_parameters(
 
     Ok(ClaimParameters(params))
 }
+
+/// Load parameters from in-memory bytes.
+///
+/// # Arguments
+/// * `bytes` - Proving key bytes
+/// * `checked` - If true, verify the parameters (slower but safer)
+///
+/// # Errors
+/// Returns an error if reading or parsing fails.
+pub fn load_parameters_from_bytes(
+    bytes: &[u8],
+    checked: bool,
+) -> Result<ClaimParameters, ParameterError> {
+    let cursor = std::io::Cursor::new(bytes);
+    let reader = std::io::BufReader::new(cursor);
+
+    let params = Parameters::read(reader, checked).map_err(ParameterError::Deserialization)?;
+
+    Ok(ClaimParameters(params))
+}

--- a/crates/zair-sapling-proofs/src/prover/convenience.rs
+++ b/crates/zair-sapling-proofs/src/prover/convenience.rs
@@ -67,6 +67,7 @@ pub fn bytes_less_than(a: &[u8; 32], b: &[u8; 32]) -> bool {
 /// Returns an error if proof generation fails.
 #[allow(
     clippy::too_many_lines,
+    clippy::similar_names,
     reason = "End-to-end witness preparation and proving"
 )]
 pub fn generate_claim_proof(

--- a/crates/zair-sapling-proofs/src/prover/mod.rs
+++ b/crates/zair-sapling-proofs/src/prover/mod.rs
@@ -5,7 +5,10 @@ mod builder;
 mod convenience;
 mod proving;
 
-pub use builder::{ParameterError, generate_parameters, load_parameters, save_parameters};
+pub use builder::{
+    ParameterError, generate_parameters, load_parameters, load_parameters_from_bytes,
+    save_parameters,
+};
 pub use convenience::generate_claim_proof;
 pub use proving::ClaimParameters;
 

--- a/crates/zair-scan/src/light_walletd.rs
+++ b/crates/zair-scan/src/light_walletd.rs
@@ -1,7 +1,9 @@
 //! Connection to lightwalletd gRPC service
 
-mod config;
-mod error;
+/// Configuration for lightwalletd connection.
+pub mod config;
+/// Errors that can occur when interacting with lightwalletd.
+pub mod error;
 mod retry;
 
 use std::ops::RangeInclusive;
@@ -56,7 +58,7 @@ impl LightWalletd {
     ///
     /// # Prerequisite
     ///
-    /// `rustls::crypto::ring::default_provider().install_default()` needs to be called
+    /// `zair_sdk::install_default_crypto_provider()` needs to be called
     /// before this function is called.
     ///
     /// # Errors
@@ -70,7 +72,7 @@ impl LightWalletd {
     ///
     /// # Prerequisite
     ///
-    /// `rustls::crypto::ring::default_provider().install_default()` needs to be called
+    /// `zair_sdk::install_default_crypto_provider()` needs to be called
     /// before this function is called.
     ///
     /// # Errors

--- a/crates/zair-scan/src/light_walletd/config.rs
+++ b/crates/zair-scan/src/light_walletd/config.rs
@@ -10,12 +10,16 @@ use crate::light_walletd::{
 /// Errors specific to `LightWalletd` configuration
 #[derive(Error, Debug)]
 pub enum ConfigError {
+    /// Returned when the initial retry delay is zero.
     #[error("Initial retry delay must be greater than zero.")]
     InitialRetryDelayZero,
+    /// Returned when the maximum retry delay is less than the initial retry delay.
     #[error("Max retry delay must be greater than or equal to initial retry delay.")]
     MaxRetryDelayLessThanInitial,
+    /// Returned when the stream message timeout is below the minimum of one second.
     #[error("Stream message timeout must be at least 1 second.")]
     StreamMessageTimeoutTooLow,
+    /// Returned when the exponential-backoff factor is below the minimum of 2.
     #[error("Backoff factor must be at least 2.")]
     BackoffFactorTooLow,
 }

--- a/crates/zair-scan/src/light_walletd/error.rs
+++ b/crates/zair-scan/src/light_walletd/error.rs
@@ -93,6 +93,7 @@ impl LightWalletdError {
         clippy::wildcard_enum_match_arm,
         reason = "We are interested in specific variants only."
     )]
+    #[must_use]
     pub fn is_retryable(&self) -> bool {
         use tonic::Code;
 

--- a/crates/zair-sdk/Cargo.toml
+++ b/crates/zair-sdk/Cargo.toml
@@ -49,6 +49,7 @@ jubjub = { workspace = true }
 pasta_curves = { workspace = true }
 rand_core = { workspace = true }
 rpassword = { workspace = true }
+rustls = { workspace = true, features = ["ring"] }
 secrecy = { workspace = true }
 thiserror = { workspace = true }
 zeroize = { workspace = true }

--- a/crates/zair-sdk/src/api/claims.rs
+++ b/crates/zair-sdk/src/api/claims.rs
@@ -1,0 +1,195 @@
+//! Claim types and processing for SDK API.
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+use tracing::{debug, info};
+use zair_core::base::{Nullifier, Pool, SanitiseNullifiers};
+use zair_core::schema::proof_inputs::{ClaimInput, PublicInputs};
+use zair_nonmembership::{
+    MerklePathError, NonMembershipTree, OrchardNonMembershipTree, TreePosition,
+};
+use zair_scan::ViewingKeys;
+
+pub use crate::commands::{
+    ClaimProofsOutput, ClaimSecretsOutput, GapTreeMode, NoteMetadata, OrchardPool, PoolClaimResult,
+    PoolProcessor, SaplingPool,
+};
+
+/// Errors that can occur during claim processing.
+#[derive(Debug, Error)]
+pub enum ClaimsError {
+    /// Returned when a non-`Sparse` gap-tree mode is passed to the in-memory tree builder.
+    #[error("In-memory build requires GapTreeMode::Sparse, got {0}")]
+    InvalidGapTreeMode(String),
+    /// Returned when the `spawn_blocking` merkle-tree construction task fails or the tree
+    /// library returns an error.
+    #[error("Failed to build {0} merkle tree: {1}")]
+    MerkleTreeBuild(String, String),
+    /// Returned when the scanned note-metadata map has no entry for a nullifier the user owns —
+    /// indicates a scanning consistency issue.
+    #[error("Missing note metadata for nullifier {0} at claim index {1}")]
+    MissingNoteMetadata(Nullifier, usize),
+    /// Returned when the sparse non-membership tree cannot produce a witness path for a given
+    /// leaf position.
+    #[error("Failed to generate merkle witness for {0}: {1}")]
+    WitnessGeneration(String, String),
+    /// Returned when note metadata cannot be converted into the pool-specific private inputs
+    /// required for proof generation.
+    #[error("Failed to convert note metadata to private inputs for {0}: {1}")]
+    PrivateInputsConversion(String, String),
+}
+
+/// Loaded pool data including the non-membership merkle-tree and user's nullifier positions.
+pub struct LoadedPoolData {
+    /// The non-membership merkle tree for the pool.
+    pub tree: PoolMerkleTree,
+    /// The user's nullifiers with tree positions needed to generate proofs.
+    pub user_nullifiers: Vec<TreePosition>,
+}
+
+/// Pool-specific non-membership tree variants.
+pub enum PoolMerkleTree {
+    /// Sapling pool non-membership tree using sparse representation.
+    SaplingSparse(NonMembershipTree),
+    /// Orchard pool non-membership tree using sparse representation.
+    OrchardSparse(OrchardNonMembershipTree),
+}
+
+impl PoolMerkleTree {
+    /// Returns the root hash of the merkle tree as 32 bytes.
+    #[must_use]
+    pub fn root_bytes(&self) -> [u8; 32] {
+        match self {
+            Self::SaplingSparse(tree) => tree.root().to_bytes(),
+            Self::OrchardSparse(tree) => tree.root_bytes(),
+        }
+    }
+
+    /// Returns the merkle path (witness) for a given leaf position.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the witness cannot be generated for the given position.
+    pub fn witness_bytes(&self, position: u64) -> Result<Vec<[u8; 32]>, MerklePathError> {
+        match self {
+            Self::SaplingSparse(tree) => tree
+                .witness(position.into())
+                .map(|path| path.into_iter().map(|node| node.to_bytes()).collect()),
+            Self::OrchardSparse(tree) => tree.witness_bytes(position.into()),
+        }
+    }
+}
+
+/// Build the non-membership merkle tree for a pool from in-memory nullifiers.
+///
+/// Only supports `Sparse` gap tree mode (no file I/O).
+///
+/// # Errors
+///
+/// Returns an error if the gap tree mode is not `Sparse` or if tree construction fails.
+pub async fn build_pool_merkle_tree_from_memory(
+    chain_nullifiers: SanitiseNullifiers,
+    user_nullifiers: SanitiseNullifiers,
+    pool: Pool,
+    gap_tree_mode: GapTreeMode,
+) -> Result<LoadedPoolData, ClaimsError> {
+    if gap_tree_mode != GapTreeMode::Sparse {
+        return Err(ClaimsError::InvalidGapTreeMode(format!(
+            "{gap_tree_mode:?}"
+        )));
+    }
+
+    let use_orchard_tree = pool == Pool::Orchard;
+
+    info!(
+        count = chain_nullifiers.len(),
+        %pool,
+        "Loaded chain nullifiers"
+    );
+    info!(
+        %pool,
+        "Building sparse non-membership tree from snapshot nullifiers..."
+    );
+
+    let chain_for_build = chain_nullifiers;
+    let user_for_build = user_nullifiers;
+    let (tree, user_positions) = tokio::task::spawn_blocking(move || {
+        if use_orchard_tree {
+            OrchardNonMembershipTree::from_chain_and_user_nullifiers_with_progress(
+                &chain_for_build,
+                &user_for_build,
+                |_current, _total| {},
+            )
+            .map(|(tree, positions)| (PoolMerkleTree::OrchardSparse(tree), positions))
+        } else {
+            NonMembershipTree::from_chain_and_user_nullifiers_with_progress(
+                &chain_for_build,
+                &user_for_build,
+                |_current, _total| {},
+            )
+            .map(|(tree, positions)| (PoolMerkleTree::SaplingSparse(tree), positions))
+        }
+    })
+    .await
+    .map_err(|e| ClaimsError::MerkleTreeBuild(pool.to_string(), e.to_string()))?
+    .map_err(|e| ClaimsError::MerkleTreeBuild(pool.to_string(), e.to_string()))?;
+
+    info!(%pool, "Non-membership tree ready");
+    Ok(LoadedPoolData {
+        tree,
+        user_nullifiers: user_positions,
+    })
+}
+
+/// Generate airdrop claims for the user's notes.
+///
+/// This generic function works with any metadata type implementing `NoteMetadata`,
+/// producing claim inputs with the appropriate pool-specific private inputs.
+///
+/// # Errors
+///
+/// Returns an error if note metadata is missing for any nullifier or if merkle witness generation
+/// fails.
+#[allow(clippy::implicit_hasher)]
+pub fn generate_claims<M: NoteMetadata>(
+    tree: &PoolMerkleTree,
+    user_nullifiers: &[TreePosition],
+    note_metadata_map: &HashMap<Nullifier, M>,
+    viewing_keys: &ViewingKeys,
+) -> Result<Vec<ClaimInput<M::PoolPrivateInputs>>, ClaimsError> {
+    user_nullifiers
+        .iter()
+        .enumerate()
+        .map(|(index, tree_position)| {
+            let metadata = note_metadata_map.get(&tree_position.nullifier).ok_or(
+                ClaimsError::MissingNoteMetadata(tree_position.nullifier, index),
+            )?;
+
+            let nf_merkle_proof = tree
+                .witness_bytes(tree_position.leaf_position.into())
+                .map_err(|e| {
+                    ClaimsError::WitnessGeneration("unknown".to_string(), e.to_string())
+                })?;
+
+            debug!(
+                index,
+                "Generated proof for nullifier {:x?} at block height {}",
+                tree_position.nullifier,
+                metadata.block_height()
+            );
+
+            let private_inputs = metadata
+                .to_private_inputs(tree_position, nf_merkle_proof, viewing_keys)
+                .map_err(|e| {
+                    ClaimsError::PrivateInputsConversion("unknown".to_string(), e.to_string())
+                })?;
+            Ok(ClaimInput {
+                public_inputs: PublicInputs {
+                    airdrop_nullifier: metadata.hiding_nullifier(),
+                },
+                private_inputs,
+            })
+        })
+        .collect()
+}

--- a/crates/zair-sdk/src/api/key.rs
+++ b/crates/zair-sdk/src/api/key.rs
@@ -1,0 +1,53 @@
+//! In-memory key derivation utilities.
+
+use thiserror::Error;
+use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_protocol::consensus::Network;
+use zip32::AccountId;
+
+/// Errors that can occur during key derivation.
+#[derive(Debug, Error)]
+pub enum KeyError {
+    /// Returned when the seed slice is not exactly 64 bytes.
+    #[error("Seed must be exactly 64 bytes, got {0}")]
+    InvalidSeedLength(usize),
+    /// Returned when the account index cannot be converted into a valid ZIP-32 `AccountId`.
+    #[error("Invalid account ID: {0}")]
+    InvalidAccountId(String),
+    /// Returned when `UnifiedSpendingKey::from_seed` fails.
+    #[error("Failed to derive spending key: {0}")]
+    KeyDerivation(String),
+}
+
+/// Derive a UFVK from an in-memory seed.
+///
+/// # Arguments
+///
+/// * `network` - Zcash network
+/// * `account_id` - ZIP-32 account index
+/// * `seed` - 64-byte BIP-39 seed
+///
+/// # Returns
+///
+/// Encoded UFVK string.
+///
+/// # Errors
+///
+/// Returns an error if key derivation fails.
+pub fn derive_ufvk_from_seed(
+    network: Network,
+    account_id: u32,
+    seed: &[u8],
+) -> Result<String, KeyError> {
+    let seed: &[u8; 64] = seed
+        .try_into()
+        .map_err(|_| KeyError::InvalidSeedLength(seed.len()))?;
+
+    let account_id =
+        AccountId::try_from(account_id).map_err(|e| KeyError::InvalidAccountId(e.to_string()))?;
+
+    let usk = UnifiedSpendingKey::from_seed(&network, seed, account_id)
+        .map_err(|e| KeyError::KeyDerivation(e.to_string()))?;
+
+    Ok(usk.to_unified_full_viewing_key().encode(&network))
+}

--- a/crates/zair-sdk/src/api/mod.rs
+++ b/crates/zair-sdk/src/api/mod.rs
@@ -1,0 +1,126 @@
+//! In-memory API for zair-sdk.
+//!
+//! This module provides file-free variants of the claim pipeline:
+//! scan -> prove -> sign.
+//! All functions accept in-memory types and return results directly,
+//! with no filesystem I/O.
+
+pub mod claims;
+pub mod key;
+#[cfg(feature = "prove")]
+pub mod prove;
+pub mod scan;
+pub mod sign;
+
+// Re-export key types for convenience
+pub use sign::ResolvedMessageHashes;
+use thiserror::Error;
+use zair_core::schema::config::AirdropConfiguration;
+use zair_core::schema::submission::ClaimSubmission;
+
+use super::common::to_zcash_network;
+use crate::api::claims::ClaimsError;
+use crate::api::key::KeyError;
+#[cfg(feature = "prove")]
+use crate::api::prove::ProveError;
+use crate::api::scan::ScanError;
+use crate::api::sign::SignError;
+
+/// Errors that can occur in the API pipeline.
+#[derive(Debug, Error)]
+pub enum ApiError {
+    /// Returned when the key-derivation sub-step fails.
+    #[error("Key derivation failed: {0}")]
+    Key(#[from] KeyError),
+    /// Returned when the chain-scanning sub-step fails.
+    #[error("Chain scanning failed: {0}")]
+    Scan(#[from] ScanError),
+    /// Returned when the proof-generation sub-step fails.
+    #[cfg(feature = "prove")]
+    #[error("Proof generation failed: {0}")]
+    Prove(#[from] ProveError),
+    /// Returned when the claim-processing sub-step fails.
+    #[error("Claim processing failed: {0}")]
+    Claims(#[from] ClaimsError),
+    /// Returned when the signing sub-step fails.
+    #[error("Signing failed: {0}")]
+    Sign(#[from] SignError),
+    /// No message hashes provided for signing.
+    ///
+    /// Provide `ResolvedMessageHashes` with at least a shared hash or per-proof hashes.
+    #[error(
+        "No message hashes provided for signing. Supply ResolvedMessageHashes with a shared hash and/or per-proof entries"
+    )]
+    MissingMessageHashes,
+}
+
+/// Run the full in-memory claim pipeline: scan -> prove -> sign.
+///
+/// # Arguments
+///
+/// * `lightwalletd_url` - gRPC endpoint (None for network default)
+/// * `sapling_snapshot_nullifiers` - Sapling nullifiers as raw bytes
+/// * `orchard_snapshot_nullifiers` - Orchard nullifiers as raw bytes
+/// * `seed` - 64-byte BIP-39 seed
+/// * `account_id` - ZIP-32 account index
+/// * `sapling_proving_key` - Groth16 proving key bytes (None if no Sapling claims)
+/// * `orchard_params_bytes` - Halo2 params bytes (None if no Orchard claims)
+/// * `birthday_height` - earliest block for note scanning
+/// * `config` - airdrop configuration
+/// * `message_hashes` - pre-computed message hashes to sign; per‑proof hashes (keyed by airdrop
+///   nullifier) take precedence over the shared fallback
+///
+/// # Errors
+///
+/// Returns an error if any step in the pipeline fails.
+#[cfg(feature = "prove")]
+#[allow(clippy::too_many_arguments, reason = "API entrypoint")]
+pub async fn run(
+    lightwalletd_url: Option<String>,
+    sapling_snapshot_nullifiers: &[u8],
+    orchard_snapshot_nullifiers: &[u8],
+    seed: &[u8],
+    account_id: u32,
+    sapling_proving_key: Option<&[u8]>,
+    orchard_params_bytes: Option<&[u8]>,
+    birthday_height: u64,
+    config: &AirdropConfiguration,
+    message_hashes: Option<ResolvedMessageHashes>,
+) -> Result<ClaimSubmission, ApiError> {
+    let ufvk = key::derive_ufvk_from_seed(to_zcash_network(config.network), account_id, seed)
+        .map_err(ApiError::Key)?;
+
+    let claims = scan::airdrop_claim_from_config(
+        lightwalletd_url,
+        sapling_snapshot_nullifiers,
+        orchard_snapshot_nullifiers,
+        &ufvk,
+        birthday_height,
+        config,
+    )
+    .await
+    .map_err(ApiError::Scan)?;
+
+    let (proofs, secrets) = prove::generate_claim_proofs_from_bytes(
+        claims,
+        seed,
+        account_id,
+        sapling_proving_key,
+        orchard_params_bytes,
+        config,
+    )
+    .await
+    .map_err(ApiError::Prove)?;
+
+    let message_hashes = message_hashes.ok_or(ApiError::MissingMessageHashes)?;
+    sign::sign_claim_submission_from_bytes(
+        proofs,
+        secrets,
+        seed,
+        account_id,
+        config,
+        &message_hashes,
+    )
+    .await
+    .map_err(ApiError::Sign)
+}

--- a/crates/zair-sdk/src/api/prove.rs
+++ b/crates/zair-sdk/src/api/prove.rs
@@ -1,0 +1,277 @@
+//! In-memory proof generation.
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tracing::info;
+use zair_core::schema::config::AirdropConfiguration;
+use zair_core::schema::proof_inputs::AirdropClaimInputs;
+use zair_orchard_proofs::ValueCommitmentScheme as OrchardValueCommitmentScheme;
+use zair_sapling_proofs::prover::{
+    ValueCommitmentScheme as SaplingValueCommitmentScheme, load_parameters_from_bytes,
+};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zip32::AccountId;
+
+use crate::api::claims::{ClaimProofsOutput, ClaimSecretsOutput};
+use crate::commands::{
+    claim_matches_seed_keys, derive_sapling_proof_generation_keys,
+    generate_sapling_proofs_parallel, generate_single_orchard_proof, read_params,
+};
+use crate::common::to_zcash_network;
+
+/// Errors that can occur during proof generation.
+#[derive(Debug, Error)]
+pub enum ProveError {
+    /// Returned when Sapling claims exist in the scan output but the airdrop configuration
+    /// lacks a Sapling pool section.
+    #[error("Sapling claims present but airdrop configuration has no sapling pool")]
+    MissingSaplingPool,
+    /// Returned when Orchard claims exist in the scan output but the airdrop configuration
+    /// lacks an Orchard pool section.
+    #[error("Orchard claims present but airdrop configuration has no orchard pool")]
+    MissingOrchardPool,
+    /// Returned when the seed slice is not exactly 64 bytes.
+    #[error("Seed must be exactly 64 bytes, got {0}")]
+    InvalidSeedLength(usize),
+    /// Returned when the account index cannot be converted into a valid ZIP-32 `AccountId`.
+    #[error("Invalid account ID: {0}")]
+    InvalidAccountId(String),
+    /// Returned when `UnifiedSpendingKey::from_seed` fails.
+    #[error("Failed to derive spending key: {0}")]
+    KeyDerivation(String),
+    /// Returned when Sapling claims exist but no Groth16 proving key bytes were supplied.
+    #[error("Sapling claims present but no proving key provided")]
+    MissingSaplingProvingKey,
+    /// Returned when Sapling proving/verifying key deserialization from bytes fails.
+    #[error("Failed to load Sapling parameters: {0}")]
+    LoadSaplingParams(String),
+    /// Returned when Sapling proof generation keys cannot be derived from the seed and account
+    /// index.
+    #[error("Derivation of Sapling proof generation keys failed: {0}")]
+    SaplingKeyDerivation(String),
+    /// Returned when Sapling keys derived from the provided seed do not match the keys embedded
+    /// in the claim inputs.
+    #[error("Seed mismatch: seed-derived Sapling keys do not match claim inputs")]
+    SaplingSeedMismatch,
+    /// Returned when the number of generated Sapling proofs does not equal the number of input
+    /// claims.
+    #[error("Expected {0} Sapling proofs, generated {1}")]
+    SaplingProofCountMismatch(usize, usize),
+    /// Returned when the number of generated Sapling secrets does not equal the number of input
+    /// claims.
+    #[error("Expected {0} Sapling secrets, generated {1}")]
+    SaplingSecretCountMismatch(usize, usize),
+    /// Returned when Orchard claims exist but no Halo2 circuit parameters bytes were supplied.
+    #[error("Orchard claims present but no params provided")]
+    MissingOrchardParams,
+    /// Returned when the Orchard target ID in the airdrop configuration exceeds 32 bytes.
+    #[error("Orchard target_id must be at most 32 bytes, got {0}")]
+    InvalidTargetIdLength(usize),
+    /// Returned when the circuit parameter `k` in the supplied Halo2 params does not match the
+    /// value commitment scheme's expected `k`.
+    #[error("Orchard params `k` mismatch: expected {expected} (scheme={scheme:?}), got {actual}")]
+    OrchardParamsKMismatch {
+        /// Expected k value.
+        expected: u32,
+        /// Actual k value from params.
+        actual: u32,
+        /// The value commitment scheme used.
+        scheme: OrchardValueCommitmentScheme,
+    },
+    /// Returned when Orchard Halo2 circuit parameters cannot be read or deserialized from raw
+    /// bytes.
+    #[error("Failed to read Orchard params: {0}")]
+    ReadOrchardParams(String),
+    /// Returned when the Halo2 proof generation for an Orchard claim fails.
+    #[error("Failed to generate Orchard proof: {0}")]
+    OrchardProofGeneration(String),
+}
+
+/// Generate claim proofs from in-memory inputs.
+///
+/// # Arguments
+///
+/// * `inputs` - claim inputs from the scan step
+/// * `seed` - 64-byte BIP-39 seed
+/// * `account_id` - ZIP-32 account index
+/// * `sapling_proving_key` - Groth16 proving key bytes (None if no Sapling claims)
+/// * `orchard_params_bytes` - Halo2 params bytes (None if no Orchard claims)
+/// * `config` - airdrop configuration
+///
+/// # Returns
+///
+/// Tuple of `(proofs, secrets)`. Secrets are needed for signing.
+///
+/// # Errors
+///
+/// Returns an error if key derivation, proof generation, or verification fails.
+#[allow(clippy::too_many_arguments, reason = "API entrypoint")]
+#[allow(clippy::too_many_lines)]
+pub async fn generate_claim_proofs_from_bytes(
+    inputs: AirdropClaimInputs,
+    seed: &[u8],
+    account_id: u32,
+    sapling_proving_key: Option<&[u8]>,
+    orchard_params_bytes: Option<&[u8]>,
+    config: &AirdropConfiguration,
+) -> Result<(ClaimProofsOutput, ClaimSecretsOutput), ProveError> {
+    let network = to_zcash_network(config.network);
+
+    let sapling_config = if inputs.sapling_claim_input.is_empty() {
+        None
+    } else {
+        Some(
+            config
+                .sapling
+                .as_ref()
+                .ok_or(ProveError::MissingSaplingPool)?
+                .clone(),
+        )
+    };
+    let sapling_scheme: SaplingValueCommitmentScheme = sapling_config
+        .as_ref()
+        .map_or(SaplingValueCommitmentScheme::Native, |s| {
+            s.value_commitment_scheme.into()
+        });
+
+    let orchard_config = if inputs.orchard_claim_input.is_empty() {
+        None
+    } else {
+        Some(
+            config
+                .orchard
+                .as_ref()
+                .ok_or(ProveError::MissingOrchardPool)?
+                .clone(),
+        )
+    };
+    let orchard_scheme: OrchardValueCommitmentScheme = orchard_config
+        .as_ref()
+        .map_or(OrchardValueCommitmentScheme::Native, |o| {
+            o.value_commitment_scheme.into()
+        });
+
+    let seed_array: &[u8; 64] = seed
+        .try_into()
+        .map_err(|_| ProveError::InvalidSeedLength(seed.len()))?;
+
+    let zip32_account =
+        AccountId::try_from(account_id).map_err(|e| ProveError::InvalidAccountId(e.to_string()))?;
+    let usk = UnifiedSpendingKey::from_seed(&network, seed_array, zip32_account)
+        .map_err(|e| ProveError::KeyDerivation(e.to_string()))?;
+
+    let (sapling_proofs, sapling_secrets) = if inputs.sapling_claim_input.is_empty() {
+        (Vec::new(), Vec::new())
+    } else {
+        let pk_bytes = sapling_proving_key.ok_or(ProveError::MissingSaplingProvingKey)?;
+
+        info!("Loading Sapling parameters from bytes...");
+        let params = tokio::task::spawn_blocking({
+            let pk_bytes = pk_bytes.to_vec();
+            move || load_parameters_from_bytes(&pk_bytes, false)
+        })
+        .await
+        .map_err(|e| ProveError::LoadSaplingParams(e.to_string()))?
+        .map_err(|e| ProveError::LoadSaplingParams(e.to_string()))?;
+        let pvk = params.prepared_verifying_key();
+        info!("Sapling parameters ready");
+
+        info!("Deriving Sapling proof generation keys...");
+        let keys = derive_sapling_proof_generation_keys(network, seed_array, account_id)
+            .map_err(|e| ProveError::SaplingKeyDerivation(e.to_string()))?;
+        info!("Derived Sapling proof generation keys (external + internal)");
+
+        if inputs
+            .sapling_claim_input
+            .iter()
+            .any(|claim| !claim_matches_seed_keys(claim, &keys))
+        {
+            return Err(ProveError::SaplingSeedMismatch);
+        }
+
+        let expected_sapling_count = inputs.sapling_claim_input.len();
+        let (sapling_proofs, sapling_secrets) = generate_sapling_proofs_parallel(
+            inputs.sapling_claim_input.clone(),
+            Arc::new(params),
+            Arc::new(pvk),
+            Arc::new(keys),
+            sapling_config
+                .as_ref()
+                .map_or([0_u8; 32], |s| s.note_commitment_root),
+            sapling_config
+                .as_ref()
+                .map_or([0_u8; 32], |s| s.nullifier_gap_root),
+            sapling_scheme,
+        )
+        .await
+        .map_err(|e| ProveError::LoadSaplingParams(e.to_string()))?;
+
+        if sapling_proofs.len() != expected_sapling_count {
+            return Err(ProveError::SaplingProofCountMismatch(
+                expected_sapling_count,
+                sapling_proofs.len(),
+            ));
+        }
+        if sapling_secrets.len() != expected_sapling_count {
+            return Err(ProveError::SaplingSecretCountMismatch(
+                expected_sapling_count,
+                sapling_secrets.len(),
+            ));
+        }
+        (sapling_proofs, sapling_secrets)
+    };
+
+    let mut orchard_proofs = Vec::with_capacity(inputs.orchard_claim_input.len());
+    let mut orchard_secrets = Vec::with_capacity(inputs.orchard_claim_input.len());
+    if let Some(orchard) = orchard_config {
+        let params_bytes = orchard_params_bytes.ok_or(ProveError::MissingOrchardParams)?;
+
+        if orchard.target_id.len() > 32 {
+            return Err(ProveError::InvalidTargetIdLength(orchard.target_id.len()));
+        }
+
+        let expected_k = zair_orchard_proofs::k_for_scheme(orchard_scheme);
+        let params = tokio::task::spawn_blocking({
+            let params_bytes = params_bytes.to_vec();
+            move || read_params(params_bytes)
+        })
+        .await
+        .map_err(|e| ProveError::ReadOrchardParams(e.to_string()))?
+        .map_err(|e| ProveError::ReadOrchardParams(e.to_string()))?;
+
+        if params.k() != expected_k {
+            return Err(ProveError::OrchardParamsKMismatch {
+                expected: expected_k,
+                actual: params.k(),
+                scheme: orchard_scheme,
+            });
+        }
+
+        for claim_input in &inputs.orchard_claim_input {
+            let (proof, secret) = generate_single_orchard_proof(
+                &params,
+                claim_input,
+                &usk,
+                orchard.note_commitment_root,
+                orchard.nullifier_gap_root,
+                &orchard.target_id,
+                orchard_scheme,
+            )
+            .map_err(|e| ProveError::OrchardProofGeneration(e.to_string()))?;
+            orchard_proofs.push(proof);
+            orchard_secrets.push(secret);
+        }
+    }
+
+    let proofs = ClaimProofsOutput {
+        sapling_proofs,
+        orchard_proofs,
+    };
+    let secrets = ClaimSecretsOutput {
+        sapling: sapling_secrets,
+        orchard: orchard_secrets,
+    };
+
+    Ok((proofs, secrets))
+}

--- a/crates/zair-sdk/src/api/scan.rs
+++ b/crates/zair-sdk/src/api/scan.rs
@@ -1,0 +1,226 @@
+//! In-memory chain scanning and claim input generation.
+
+use std::str::FromStr as _;
+
+use http::Uri;
+use thiserror::Error;
+use tracing::{info, instrument, warn};
+use zair_core::base::SanitiseNullifiers;
+use zair_core::schema::config::AirdropConfiguration;
+use zair_core::schema::proof_inputs::AirdropClaimInputs;
+use zair_scan::ViewingKeys;
+use zair_scan::light_walletd::LightWalletd;
+use zair_scan::light_walletd::error::LightWalletdError;
+use zair_scan::scanner::{AccountNotesVisitor, ScannerError};
+use zcash_keys::keys::UnifiedFullViewingKey;
+
+use crate::api::claims::{
+    GapTreeMode, OrchardPool, PoolClaimResult, PoolProcessor, SaplingPool,
+    build_pool_merkle_tree_from_memory, generate_claims,
+};
+use crate::common::{resolve_lightwalletd_url, to_zcash_network};
+
+/// Errors that can occur during chain scanning.
+#[derive(Debug, Error)]
+pub enum ScanError {
+    /// Returned when the airdrop configuration requires a pool's snapshot nullifiers but none
+    /// were provided.
+    #[error("{0} snapshot nullifiers are required by the airdrop configuration")]
+    MissingSnapshotNullifiers(String),
+    /// Returned when a pool section is absent from the airdrop configuration while processing
+    /// notes for that pool.
+    #[error("{0} pool is unexpectedly missing in the airdrop configuration")]
+    MissingPoolConfig(String),
+    /// Returned when the non-membership tree root computed from snapshot nullifiers does not
+    /// match the root stored in the airdrop configuration.
+    #[error("{0} merkle root mismatch with airdrop configuration")]
+    MerkleRootMismatch(String),
+    /// Returned when the UFVK string cannot be decoded for the configured network.
+    #[error("Failed to decode Unified Full Viewing Key: {0}")]
+    InvalidUfvk(String),
+    /// Returned when the binary snapshot nullifier bytes cannot be parsed into valid nullifiers.
+    #[error("Failed to parse {0} snapshot nullifiers: {1}")]
+    InvalidNullifiers(String, String),
+    /// Returned when claim input assembly fails — tree building, witness generation, or
+    /// metadata conversion.
+    #[error("Failed to generate {0} claims: {1}")]
+    ClaimGeneration(String, String),
+    /// Returned when a lightwalletd gRPC call or connection fails.
+    #[error("Lightwalletd error: {0}")]
+    Lightwalletd(#[from] LightWalletdError),
+    /// Returned when the block scanner encounters an error parsing tree state or commitment
+    /// trees.
+    #[error("Scanner error: {0}")]
+    Scanner(#[from] ScannerError),
+}
+
+#[instrument(level = "debug", skip_all, fields(pool = %P::POOL))]
+pub(crate) async fn process_pool_claims_from_memory<P: PoolProcessor>(
+    pool_enabled_in_config: bool,
+    visitor: &AccountNotesVisitor,
+    viewing_keys: &ViewingKeys,
+    airdrop_config: &AirdropConfiguration,
+    snapshot_nullifiers: Option<SanitiseNullifiers>,
+    gap_tree_mode: GapTreeMode,
+) -> Result<PoolClaimResult<P::PrivateInputs>, ScanError> {
+    if !pool_enabled_in_config {
+        return Ok(PoolClaimResult::empty());
+    }
+
+    let Some(snapshot_nullifiers) = snapshot_nullifiers else {
+        return Err(ScanError::MissingSnapshotNullifiers(P::POOL.to_string()));
+    };
+
+    let notes = match P::collect_notes(visitor, viewing_keys, airdrop_config) {
+        Ok(Some(notes)) => notes,
+        Ok(None) => {
+            warn!("UFVK has no {} viewing key; skipping", P::POOL);
+            return Ok(PoolClaimResult::empty());
+        }
+        Err(e) => {
+            return Err(ScanError::ClaimGeneration(
+                P::POOL.to_string(),
+                e.to_string(),
+            ));
+        }
+    };
+
+    let user_nullifiers = SanitiseNullifiers::new(notes.keys().copied().collect());
+    let pool_data = build_pool_merkle_tree_from_memory(
+        snapshot_nullifiers,
+        user_nullifiers,
+        P::POOL,
+        gap_tree_mode,
+    )
+    .await
+    .map_err(|e| ScanError::ClaimGeneration(P::POOL.to_string(), e.to_string()))?;
+
+    let anchor = pool_data.tree.root_bytes();
+    let Some(expected_root) = P::expected_root(airdrop_config) else {
+        return Err(ScanError::MissingPoolConfig(P::POOL.to_string()));
+    };
+    if expected_root != anchor {
+        return Err(ScanError::MerkleRootMismatch(P::POOL.to_string()));
+    }
+
+    info!(
+        pool = %P::POOL,
+        "Extracting witness paths for user nullifiers"
+    );
+    let claims = generate_claims(
+        &pool_data.tree,
+        &pool_data.user_nullifiers,
+        &notes,
+        viewing_keys,
+    )
+    .map_err(|e| ScanError::ClaimGeneration(P::POOL.to_string(), e.to_string()))?;
+
+    Ok(PoolClaimResult { claims })
+}
+
+/// Scan the chain for eligible notes and produce claim inputs.
+///
+/// # Arguments
+///
+/// * `lightwalletd_url` - gRPC endpoint (None for network default)
+/// * `sapling_snapshot_nullifiers` - Sapling nullifiers as raw bytes (from binary snapshot file)
+/// * `orchard_snapshot_nullifiers` - Orchard nullifiers as raw bytes (from binary snapshot file)
+/// * `ufvk_encoded` - encoded Unified Full Viewing Key string
+/// * `birthday_height` - earliest block for note scanning
+/// * `config` - airdrop configuration
+///
+/// # Returns
+///
+/// `AirdropClaimInputs` ready for the proving step.
+///
+/// # Errors
+///
+/// Returns an error if scanning, tree building, or claim assembly fails.
+#[allow(clippy::too_many_arguments, reason = "API entrypoint")]
+pub async fn airdrop_claim_from_config(
+    lightwalletd_url: Option<String>,
+    sapling_snapshot_nullifiers: &[u8],
+    orchard_snapshot_nullifiers: &[u8],
+    ufvk_encoded: &str,
+    birthday_height: u64,
+    config: &AirdropConfiguration,
+) -> Result<AirdropClaimInputs, ScanError> {
+    let network = to_zcash_network(config.network);
+    let lightwalletd_url = resolve_lightwalletd_url(network, lightwalletd_url.as_deref());
+
+    let ufvk =
+        UnifiedFullViewingKey::decode(&network, ufvk_encoded).map_err(ScanError::InvalidUfvk)?;
+
+    let viewing_keys = ViewingKeys::new(&ufvk);
+
+    let lightwalletd_url = Uri::from_str(&lightwalletd_url)
+        .map_err(|e| ScanError::InvalidUfvk(format!("Invalid URI: {e}")))?;
+    let lightwalletd = LightWalletd::connect(lightwalletd_url).await?;
+
+    let tree_state = lightwalletd
+        .get_tree_state(birthday_height.saturating_sub(1))
+        .await?;
+    let visitor = AccountNotesVisitor::from_tree_state(&tree_state)?;
+
+    let scan_range = birthday_height..=config.snapshot_height;
+    let initial_metadata = zair_scan::scanner::BlockScanner::parse_tree_state(&tree_state)?;
+
+    let (visitor, _final_metadata) = lightwalletd
+        .scan_blocks_spawned(ufvk, network, visitor, &scan_range, Some(initial_metadata))
+        .await?;
+
+    info!(
+        total = visitor
+            .sapling_notes()
+            .len()
+            .checked_add(visitor.orchard_notes().len()),
+        "Scan complete"
+    );
+
+    let sapling_nullifiers = if config.sapling.is_some() && !sapling_snapshot_nullifiers.is_empty()
+    {
+        Some(
+            zair_scan::read_nullifiers(sapling_snapshot_nullifiers)
+                .await
+                .map_err(|e| ScanError::InvalidNullifiers("Sapling".to_string(), e.to_string()))?,
+        )
+    } else {
+        None
+    };
+
+    let orchard_nullifiers = if config.orchard.is_some() && !orchard_snapshot_nullifiers.is_empty()
+    {
+        Some(
+            zair_scan::read_nullifiers(orchard_snapshot_nullifiers)
+                .await
+                .map_err(|e| ScanError::InvalidNullifiers("Orchard".to_string(), e.to_string()))?,
+        )
+    } else {
+        None
+    };
+
+    let sapling_result = process_pool_claims_from_memory::<SaplingPool>(
+        config.sapling.is_some(),
+        &visitor,
+        &viewing_keys,
+        config,
+        sapling_nullifiers.map(SanitiseNullifiers::new),
+        GapTreeMode::Sparse,
+    )
+    .await?;
+
+    let orchard_result = process_pool_claims_from_memory::<OrchardPool>(
+        config.orchard.is_some(),
+        &visitor,
+        &viewing_keys,
+        config,
+        orchard_nullifiers.map(SanitiseNullifiers::new),
+        GapTreeMode::Sparse,
+    )
+    .await?;
+
+    Ok(AirdropClaimInputs {
+        sapling_claim_input: sapling_result.claims,
+        orchard_claim_input: orchard_result.claims,
+    })
+}

--- a/crates/zair-sdk/src/api/sign.rs
+++ b/crates/zair-sdk/src/api/sign.rs
@@ -1,0 +1,411 @@
+//! In-memory claim signing.
+
+use std::collections::BTreeMap;
+
+use thiserror::Error;
+use tracing::info;
+use zair_core::base::{Nullifier, Pool, signature_digest};
+use zair_core::schema::config::AirdropConfiguration;
+use zair_core::schema::submission::{ClaimSubmission, OrchardSignedClaim, SaplingSignedClaim};
+
+use crate::api::claims::{ClaimProofsOutput, ClaimSecretsOutput};
+use crate::commands::submission_auth::{orchard, sapling};
+use crate::commands::{ensure_unique_airdrop_nullifiers, hash_orchard_proof, hash_sapling_proof};
+use crate::common::to_zcash_network;
+
+/// Errors that can occur during claim signing.
+#[derive(Debug, Error)]
+pub enum SignError {
+    /// Returned when both Sapling and Orchard proof lists are empty.
+    #[error("No proofs found to sign")]
+    NoProofs,
+    /// Returned when Sapling secrets are supplied but no Sapling proofs exist.
+    #[error("Sapling secrets provided without Sapling proofs")]
+    MismatchedSaplingSecrets,
+    /// Returned when Orchard secrets are supplied but no Orchard proofs exist.
+    #[error("Orchard secrets provided without Orchard proofs")]
+    MismatchedOrchardSecrets,
+    /// Returned when the Sapling proof count does not equal the Sapling secret count.
+    #[error("Proof/secret count mismatch for Sapling entries: {0} proofs vs {1} secrets")]
+    SaplingCountMismatch(usize, usize),
+    /// Returned when the Orchard proof count does not equal the Orchard secret count.
+    #[error("Proof/secret count mismatch for Orchard entries: {0} proofs vs {1} secrets")]
+    OrchardCountMismatch(usize, usize),
+    /// Returned when two Sapling secrets share the same airdrop nullifier.
+    #[error("Duplicate Sapling secret entry for airdrop nullifier: {0:?}")]
+    DuplicateSaplingSecret(Nullifier),
+    /// Returned when two Orchard secrets share the same airdrop nullifier.
+    #[error("Duplicate Orchard secret entry for airdrop nullifier: {0:?}")]
+    DuplicateOrchardSecret(Nullifier),
+    /// Returned when no matching secret is found for a proof's airdrop nullifier.
+    #[error("Missing secret material for {0} proof entry with nullifier: {1:?}")]
+    MissingSecret(String, Nullifier),
+    /// Returned when Sapling proofs exist but the airdrop configuration has no Sapling pool
+    /// section.
+    #[error("Sapling proofs provided but airdrop configuration has no Sapling pool")]
+    MissingSaplingPool,
+    /// Returned when Orchard proofs exist but the airdrop configuration has no Orchard pool
+    /// section.
+    #[error("Orchard proofs provided but airdrop configuration has no Orchard pool")]
+    MissingOrchardPool,
+    /// Returned when the spend-auth signing key has not been derived for the pool.
+    #[error("{0} signing key should be initialized")]
+    MissingSigningKey(String),
+    /// Returned when no message hash (shared or per-proof) is available for a claim's airdrop
+    /// nullifier.
+    #[error("No message provided for {0} claim with nullifier: {1:?}")]
+    MissingMessageHash(String, Nullifier),
+    /// Returned when the signature digest computation fails for a claim.
+    #[error("Failed to compute signature digest for {0}: {1}")]
+    DigestError(String, String),
+    /// Returned when the spend-authority signature generation fails.
+    #[error("Failed to sign {0} claim: {1}")]
+    SigningError(String, String),
+    /// Returned when the spend-auth key derivation from seed and account index fails.
+    #[error("Failed to derive {0} signing key: {1}")]
+    KeyDerivation(String, String),
+}
+
+/// Pre-computed message hashes for signing, with per‑pool per‑proof maps and a shared fallback.
+///
+/// Per‑proof hashes (keyed by airdrop nullifier) take precedence over the shared hash for
+/// matching nullifiers.  At least one of `shared` or the relevant per‑proof entry must be
+/// present for every proof that is signed.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedMessageHashes {
+    /// Shared message hash applied to all proofs (unless overridden by a per‑proof entry).
+    pub shared: Option<[u8; 32]>,
+    /// Per‑proof Sapling message hashes keyed by airdrop nullifier.
+    pub sapling: BTreeMap<Nullifier, [u8; 32]>,
+    /// Per‑proof Orchard message hashes keyed by airdrop nullifier.
+    pub orchard: BTreeMap<Nullifier, [u8; 32]>,
+}
+
+impl ResolvedMessageHashes {
+    /// Returns `true` if no messages are provided at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.shared.is_none() && self.sapling.is_empty() && self.orchard.is_empty()
+    }
+
+    /// Resolve the Sapling message hash for a given nullifier.
+    #[must_use]
+    pub fn sapling_hash(&self, nullifier: Nullifier) -> Option<[u8; 32]> {
+        self.sapling.get(&nullifier).copied().or(self.shared)
+    }
+
+    /// Resolve the Orchard message hash for a given nullifier.
+    #[must_use]
+    pub fn orchard_hash(&self, nullifier: Nullifier) -> Option<[u8; 32]> {
+        self.orchard.get(&nullifier).copied().or(self.shared)
+    }
+}
+
+/// Sign claim proofs into a submission package.
+///
+/// # Arguments
+///
+/// * `proofs` - generated claim proofs
+/// * `secrets` - proof generation secrets (from the prove step)
+/// * `seed` - 64-byte BIP-39 seed
+/// * `account_id` - ZIP-32 account index
+/// * `config` - airdrop configuration
+/// * `message_hashes` - pre-computed message hashes to sign; per‑proof hashes (keyed by airdrop
+///   nullifier) take precedence over the shared fallback
+///
+/// # Returns
+///
+/// Signed `ClaimSubmission` ready for the target chain.
+///
+/// # Errors
+///
+/// Returns an error if inputs are invalid, key derivation fails, or signing fails.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::similar_names,
+    clippy::unused_async,
+    clippy::too_many_lines,
+    reason = "API entrypoint"
+)]
+pub async fn sign_claim_submission_from_bytes(
+    proofs: ClaimProofsOutput,
+    secrets: ClaimSecretsOutput,
+    seed: &[u8],
+    account_id: u32,
+    config: &AirdropConfiguration,
+    message_hashes: &ResolvedMessageHashes,
+) -> Result<ClaimSubmission, SignError> {
+    if proofs.sapling_proofs.is_empty() && proofs.orchard_proofs.is_empty() {
+        return Err(SignError::NoProofs);
+    }
+    if proofs.sapling_proofs.is_empty() && !secrets.sapling.is_empty() {
+        return Err(SignError::MismatchedSaplingSecrets);
+    }
+    if proofs.orchard_proofs.is_empty() && !secrets.orchard.is_empty() {
+        return Err(SignError::MismatchedOrchardSecrets);
+    }
+    if proofs.sapling_proofs.len() != secrets.sapling.len() {
+        return Err(SignError::SaplingCountMismatch(
+            proofs.sapling_proofs.len(),
+            secrets.sapling.len(),
+        ));
+    }
+    if proofs.orchard_proofs.len() != secrets.orchard.len() {
+        return Err(SignError::OrchardCountMismatch(
+            proofs.orchard_proofs.len(),
+            secrets.orchard.len(),
+        ));
+    }
+    ensure_unique_airdrop_nullifiers(
+        proofs
+            .sapling_proofs
+            .iter()
+            .map(|proof| proof.airdrop_nullifier),
+        "Sapling proof",
+    )
+    .map_err(|e| {
+        SignError::DigestError("sapling nullifier uniqueness".to_string(), e.to_string())
+    })?;
+    ensure_unique_airdrop_nullifiers(
+        proofs
+            .orchard_proofs
+            .iter()
+            .map(|proof| proof.airdrop_nullifier),
+        "Orchard proof",
+    )
+    .map_err(|e| {
+        SignError::DigestError("orchard nullifier uniqueness".to_string(), e.to_string())
+    })?;
+
+    let seed_array: &[u8; 64] = seed.try_into().map_err(|_| {
+        SignError::DigestError("seed".to_string(), "must be exactly 64 bytes".to_string())
+    })?;
+
+    let network = to_zcash_network(config.network);
+
+    let sapling_target_id = if proofs.sapling_proofs.is_empty() {
+        None
+    } else {
+        Some(
+            config
+                .sapling
+                .as_ref()
+                .ok_or(SignError::MissingSaplingPool)?
+                .target_id
+                .clone(),
+        )
+    };
+    let orchard_target_id = if proofs.orchard_proofs.is_empty() {
+        None
+    } else {
+        Some(
+            config
+                .orchard
+                .as_ref()
+                .ok_or(SignError::MissingOrchardPool)?
+                .target_id
+                .clone(),
+        )
+    };
+
+    let sapling_keys = if proofs.sapling_proofs.is_empty() {
+        None
+    } else {
+        Some(
+            sapling::derive_spend_auth_keys(network, seed_array, account_id)
+                .map_err(|e| SignError::KeyDerivation("sapling".to_string(), e.to_string()))?,
+        )
+    };
+    let orchard_key = if proofs.orchard_proofs.is_empty() {
+        None
+    } else {
+        Some(
+            orchard::derive_spend_auth_key(network, seed_array, account_id)
+                .map_err(|e| SignError::KeyDerivation("orchard".to_string(), e.to_string()))?,
+        )
+    };
+
+    let mut sapling_secret_by_nf = BTreeMap::new();
+    for secret in secrets.sapling {
+        let nullifier = secret.airdrop_nullifier;
+        let existing = sapling_secret_by_nf.insert(nullifier, secret);
+        if existing.is_some() {
+            return Err(SignError::DuplicateSaplingSecret(nullifier));
+        }
+    }
+
+    let target_id = sapling_target_id
+        .as_deref()
+        .ok_or_else(|| SignError::MissingSigningKey("Sapling".to_string()))?;
+    let keys = sapling_keys
+        .as_ref()
+        .ok_or_else(|| SignError::MissingSigningKey("Sapling".to_string()))?;
+
+    let mut sapling = Vec::with_capacity(proofs.sapling_proofs.len());
+    for proof in &proofs.sapling_proofs {
+        let secret = sapling_secret_by_nf
+            .get(&proof.airdrop_nullifier)
+            .ok_or_else(|| {
+                SignError::MissingSecret("Sapling".to_string(), proof.airdrop_nullifier)
+            })?;
+        let msg_hash = message_hashes
+            .sapling_hash(proof.airdrop_nullifier)
+            .ok_or_else(|| {
+                SignError::MissingMessageHash("Sapling".to_string(), proof.airdrop_nullifier)
+            })?;
+        let proof_hash = hash_sapling_proof(proof);
+        let digest = signature_digest(Pool::Sapling, target_id.as_bytes(), &proof_hash, &msg_hash)
+            .map_err(|e| SignError::DigestError("Sapling".to_string(), e.to_string()))?;
+
+        let spend_auth_sig = sapling::sign_claim(proof, secret, keys, &digest)
+            .map_err(|e| SignError::SigningError("Sapling".to_string(), e.to_string()))?;
+        sapling.push(SaplingSignedClaim {
+            zkproof: proof.zkproof,
+            rk: proof.rk,
+            cv: proof.cv,
+            cv_sha256: proof.cv_sha256,
+            airdrop_nullifier: proof.airdrop_nullifier,
+            proof_hash,
+            message_hash: msg_hash,
+            spend_auth_sig,
+        });
+    }
+
+    let mut orchard_secret_by_nf = BTreeMap::new();
+    for secret in secrets.orchard {
+        let nullifier = secret.airdrop_nullifier;
+        let existing = orchard_secret_by_nf.insert(nullifier, secret);
+        if existing.is_some() {
+            return Err(SignError::DuplicateOrchardSecret(nullifier));
+        }
+    }
+
+    let target_id = orchard_target_id
+        .as_deref()
+        .ok_or_else(|| SignError::MissingSigningKey("Orchard".to_string()))?;
+    let key = orchard_key
+        .as_ref()
+        .ok_or_else(|| SignError::MissingSigningKey("Orchard".to_string()))?;
+
+    let mut orchard = Vec::with_capacity(proofs.orchard_proofs.len());
+    for proof in &proofs.orchard_proofs {
+        let secret = orchard_secret_by_nf
+            .get(&proof.airdrop_nullifier)
+            .ok_or_else(|| {
+                SignError::MissingSecret("Orchard".to_string(), proof.airdrop_nullifier)
+            })?;
+        let msg_hash = message_hashes
+            .orchard_hash(proof.airdrop_nullifier)
+            .ok_or_else(|| {
+                SignError::MissingMessageHash("Orchard".to_string(), proof.airdrop_nullifier)
+            })?;
+        let proof_hash = hash_orchard_proof(proof)
+            .map_err(|e| SignError::DigestError("Orchard".to_string(), e.to_string()))?;
+        let digest = signature_digest(Pool::Orchard, target_id.as_bytes(), &proof_hash, &msg_hash)
+            .map_err(|e| SignError::DigestError("Orchard".to_string(), e.to_string()))?;
+
+        let spend_auth_sig = orchard::sign_claim(proof, secret, key, &digest)
+            .map_err(|e| SignError::SigningError("Orchard".to_string(), e.to_string()))?;
+        orchard.push(OrchardSignedClaim {
+            zkproof: proof.zkproof.clone(),
+            rk: proof.rk,
+            cv: proof.cv,
+            cv_sha256: proof.cv_sha256,
+            airdrop_nullifier: proof.airdrop_nullifier,
+            proof_hash,
+            message_hash: msg_hash,
+            spend_auth_sig,
+        });
+    }
+
+    let submission = ClaimSubmission { sapling, orchard };
+
+    info!(
+        sapling_count = submission.sapling.len(),
+        orchard_count = submission.orchard.len(),
+        "Claim submission signed"
+    );
+
+    Ok(submission)
+}
+
+#[cfg(test)]
+mod tests {
+    use zair_core::base::hash_message;
+
+    use super::*;
+
+    #[test]
+    fn resolved_message_hashes_is_empty() {
+        let input = ResolvedMessageHashes::default();
+        assert!(input.is_empty());
+    }
+
+    #[test]
+    fn resolved_message_hashes_shared_not_empty() {
+        let hash = hash_message(b"hello");
+        let input = ResolvedMessageHashes {
+            shared: Some(hash),
+            ..Default::default()
+        };
+        assert!(!input.is_empty());
+        assert_eq!(input.shared, Some(hash));
+    }
+
+    #[test]
+    fn resolved_message_hashes_sapling_per_proof() {
+        let nullifier = Nullifier::default();
+        let hash = hash_message(b"world");
+        let mut sapling = BTreeMap::new();
+        sapling.insert(nullifier, hash);
+        let input = ResolvedMessageHashes {
+            sapling,
+            ..Default::default()
+        };
+        assert!(!input.is_empty());
+        assert_eq!(input.sapling_hash(nullifier), Some(hash));
+        assert_eq!(input.orchard_hash(nullifier), None);
+    }
+
+    #[test]
+    fn resolved_message_hashes_orchard_per_proof() {
+        let nullifier = Nullifier::default();
+        let hash = hash_message(b"orchard");
+        let mut orchard = BTreeMap::new();
+        orchard.insert(nullifier, hash);
+        let input = ResolvedMessageHashes {
+            orchard,
+            ..Default::default()
+        };
+        assert!(!input.is_empty());
+        assert_eq!(input.orchard_hash(nullifier), Some(hash));
+        assert_eq!(input.sapling_hash(nullifier), None);
+    }
+
+    #[test]
+    fn resolved_message_hashes_per_proof_overrides_shared() {
+        let nullifier = Nullifier::default();
+        let shared = hash_message(b"shared");
+        let per_proof = hash_message(b"per-proof");
+        let mut sapling = BTreeMap::new();
+        sapling.insert(nullifier, per_proof);
+        let input = ResolvedMessageHashes {
+            shared: Some(shared),
+            sapling,
+            ..Default::default()
+        };
+        assert_eq!(input.sapling_hash(nullifier), Some(per_proof));
+    }
+
+    #[test]
+    fn resolved_message_hashes_shared_fallback() {
+        let nullifier = Nullifier::default();
+        let shared = hash_message(b"shared");
+        let input = ResolvedMessageHashes {
+            shared: Some(shared),
+            ..Default::default()
+        };
+        assert_eq!(input.sapling_hash(nullifier), Some(shared));
+        assert_eq!(input.orchard_hash(nullifier), Some(shared));
+    }
+}

--- a/crates/zair-sdk/src/commands.rs
+++ b/crates/zair-sdk/src/commands.rs
@@ -18,23 +18,35 @@ mod orchard_setup;
 mod pool_processor;
 mod sensitive_output;
 mod signature_digest;
-mod submission_auth;
+pub(crate) mod submission_auth;
 mod submission_messages;
 mod workflows;
 
 pub use airdrop_claim::{GapTreeMode, airdrop_claim};
 pub use airdrop_configuration::build_airdrop_configuration;
-pub use claim_proofs::verify_claim_proofs;
+pub use claim_proofs::{ClaimProofsOutput, ClaimSecretsOutput, verify_claim_proofs};
+// TODO: Move definitions outside the `command` module crate.
+/// Utilities used within the integration API.
+#[cfg(feature = "prove")]
+pub(crate) use claim_proofs_prove::{
+    claim_matches_seed_keys, derive_sapling_proof_generation_keys,
+    generate_sapling_proofs_parallel, generate_single_orchard_proof,
+};
 #[cfg(feature = "prove")]
 pub use claim_proofs_prove::{generate_claim_params, generate_claim_proofs};
 pub use claim_submission_sign::sign_claim_submission;
 pub use claim_submission_verify::verify_claim_submission_signature;
 pub use key::{MnemonicSource, key_derive_seed, key_derive_ufvk};
+pub use note_metadata::NoteMetadata;
+pub(crate) use nullifier_uniqueness::ensure_unique_airdrop_nullifiers;
+pub(crate) use orchard_params::read_params;
 pub use orchard_params::{
     OrchardParamsMode, generate_orchard_params_file, load_or_prepare_orchard_params,
 };
 #[cfg(feature = "prove")]
 pub use orchard_setup::generate_orchard_params;
+pub use pool_processor::{OrchardPool, PoolClaimResult, PoolProcessor, SaplingPool};
+pub(crate) use signature_digest::{hash_orchard_proof, hash_sapling_proof};
 #[cfg(feature = "prove")]
 pub use workflows::claim_run;
 pub use workflows::verify_run;

--- a/crates/zair-sdk/src/commands/claim_proofs_prove.rs
+++ b/crates/zair-sdk/src/commands/claim_proofs_prove.rs
@@ -142,13 +142,13 @@ pub async fn generate_claim_params(
 }
 
 /// Sapling proof generation keys for both external and internal scopes.
-struct SaplingProofGenerationKeys {
+pub struct SaplingProofGenerationKeys {
     external: sapling::ProofGenerationKey,
     internal: sapling::ProofGenerationKey,
 }
 
 /// Derive Sapling proof generation keys from a seed.
-fn derive_sapling_proof_generation_keys(
+pub fn derive_sapling_proof_generation_keys(
     network: Network,
     seed: &[u8; 64],
     account_id: u32,
@@ -168,7 +168,7 @@ fn derive_sapling_proof_generation_keys(
 
 /// Returns true when claim key material matches seed-derived key material for its scope.
 #[allow(clippy::similar_names)]
-fn claim_matches_seed_keys(
+pub fn claim_matches_seed_keys(
     claim_input: &ClaimInput<SaplingPrivateInputs>,
     keys: &SaplingProofGenerationKeys,
 ) -> bool {
@@ -261,7 +261,7 @@ fn generate_single_sapling_proof(
 }
 
 /// Generate Sapling proofs in parallel using tokio's blocking thread pool.
-async fn generate_sapling_proofs_parallel(
+pub async fn generate_sapling_proofs_parallel(
     sapling_inputs: Vec<ClaimInput<SaplingPrivateInputs>>,
     params: Arc<ClaimParameters>,
     pvk: Arc<PreparedVerifyingKey<Bls12>>,
@@ -393,7 +393,7 @@ fn orchard_target_id_bytes(target_id: &str) -> eyre::Result<([u8; 32], u8)> {
     clippy::too_many_lines,
     reason = "Per-claim Orchard proving needs explicit material"
 )]
-fn generate_single_orchard_proof(
+pub fn generate_single_orchard_proof(
     params: &Params<vesta::Affine>,
     claim_input: &ClaimInput<OrchardPrivateInputs>,
     usk: &UnifiedSpendingKey,

--- a/crates/zair-sdk/src/commands/claim_submission_sign.rs
+++ b/crates/zair-sdk/src/commands/claim_submission_sign.rs
@@ -1,33 +1,22 @@
 //! Claim submission signing command implementation.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use eyre::{Context as _, ContextCompat as _, ensure};
+use eyre::Context as _;
 use secrecy::ExposeSecret;
 use tracing::info;
-use zair_core::base::{Pool, signature_digest};
 use zair_core::schema::config::AirdropConfiguration;
-use zair_core::schema::submission::{ClaimSubmission, OrchardSignedClaim, SaplingSignedClaim};
 
 use super::claim_proofs::{ClaimProofsOutput, ClaimSecretsOutput};
-use super::nullifier_uniqueness::ensure_unique_airdrop_nullifiers;
-use super::signature_digest::{hash_orchard_proof, hash_sapling_proof};
-use super::submission_auth::{orchard, sapling};
 use super::submission_messages::resolve_message_hashes;
-use crate::common::to_zcash_network;
+use crate::api::sign::sign_claim_submission_from_bytes;
 use crate::seed::read_seed_file;
 
 /// Sign claim proofs into a submission package.
 ///
 /// # Errors
 /// Returns an error if inputs are invalid, key derivation fails, or signing fails.
-#[allow(
-    clippy::too_many_lines,
-    clippy::too_many_arguments,
-    clippy::similar_names,
-    reason = "CLI entrypoint parameters"
-)]
+#[allow(clippy::too_many_arguments)]
 pub async fn sign_claim_submission(
     proofs_file: PathBuf,
     secrets_file: PathBuf,
@@ -35,7 +24,7 @@ pub async fn sign_claim_submission(
     account_id: u32,
     airdrop_configuration_file: PathBuf,
     message_file: Option<PathBuf>,
-    messages_file: Option<PathBuf>,
+    messages_path: Option<PathBuf>,
     submission_output_file: PathBuf,
 ) -> eyre::Result<()> {
     info!(file = ?proofs_file, "Loading proofs for signing...");
@@ -48,195 +37,26 @@ pub async fn sign_claim_submission(
         serde_json::from_str(&tokio::fs::read_to_string(&secrets_file).await?)
             .context("Failed to parse secrets JSON")?;
 
-    ensure!(
-        !(proofs.sapling_proofs.is_empty() && proofs.orchard_proofs.is_empty()),
-        "No proofs found to sign"
-    );
-    ensure!(
-        !proofs.sapling_proofs.is_empty() || secrets.sapling.is_empty(),
-        "Sapling secrets provided without Sapling proofs"
-    );
-    ensure!(
-        !proofs.orchard_proofs.is_empty() || secrets.orchard.is_empty(),
-        "Orchard secrets provided without Orchard proofs"
-    );
-    ensure!(
-        proofs.sapling_proofs.len() == secrets.sapling.len(),
-        "Proof/secret count mismatch for Sapling entries"
-    );
-    ensure!(
-        proofs.orchard_proofs.len() == secrets.orchard.len(),
-        "Proof/secret count mismatch for Orchard entries"
-    );
-    ensure_unique_airdrop_nullifiers(
-        proofs
-            .sapling_proofs
-            .iter()
-            .map(|proof| proof.airdrop_nullifier),
-        "Sapling proof",
-    )?;
-    ensure_unique_airdrop_nullifiers(
-        proofs
-            .orchard_proofs
-            .iter()
-            .map(|proof| proof.airdrop_nullifier),
-        "Orchard proof",
-    )?;
-
-    let airdrop_config: AirdropConfiguration =
+    info!(file = ?airdrop_configuration_file, "Loading airdrop configuration...");
+    let config: AirdropConfiguration =
         serde_json::from_str(&tokio::fs::read_to_string(&airdrop_configuration_file).await?)
             .context("Failed to parse airdrop configuration JSON")?;
-
-    let sapling_target_id = if proofs.sapling_proofs.is_empty() {
-        None
-    } else {
-        Some(
-            airdrop_config
-                .sapling
-                .as_ref()
-                .context("Sapling proofs provided, but airdrop configuration has no sapling pool")?
-                .target_id
-                .clone(),
-        )
-    };
-    let orchard_target_id = if proofs.orchard_proofs.is_empty() {
-        None
-    } else {
-        Some(
-            airdrop_config
-                .orchard
-                .as_ref()
-                .context("Orchard proofs provided, but airdrop configuration has no orchard pool")?
-                .target_id
-                .clone(),
-        )
-    };
 
     info!(file = ?seed_file, "Reading seed from file...");
     let seed = read_seed_file(&seed_file).await?;
 
-    let network = to_zcash_network(airdrop_config.network);
-    let sapling_keys = if proofs.sapling_proofs.is_empty() {
-        None
-    } else {
-        Some(sapling::derive_spend_auth_keys(
-            network,
-            seed.expose_secret(),
-            account_id,
-        )?)
-    };
-    let orchard_key = if proofs.orchard_proofs.is_empty() {
-        None
-    } else {
-        Some(orchard::derive_spend_auth_key(
-            network,
-            seed.expose_secret(),
-            account_id,
-        )?)
-    };
+    let resolved = resolve_message_hashes(message_file.as_ref(), messages_path.as_ref()).await?;
 
-    let message_hashes =
-        resolve_message_hashes(message_file.as_ref(), messages_file.as_ref()).await?;
-
-    let mut sapling_secret_by_nf = BTreeMap::new();
-    for secret in secrets.sapling {
-        let existing = sapling_secret_by_nf.insert(secret.airdrop_nullifier, secret);
-        ensure!(
-            existing.is_none(),
-            "Duplicate Sapling secret entry for airdrop nullifier"
-        );
-    }
-
-    let mut sapling = Vec::with_capacity(proofs.sapling_proofs.len());
-    for proof in &proofs.sapling_proofs {
-        let secret = sapling_secret_by_nf
-            .get(&proof.airdrop_nullifier)
-            .context("Missing secret material for Sapling proof entry")?;
-        let target_id = sapling_target_id
-            .as_deref()
-            .context("Sapling target_id must be present for Sapling signing")?;
-        let message_hash = message_hashes
-            .sapling_hash(proof.airdrop_nullifier)
-            .with_context(|| {
-                format!(
-                    "No message provided for Sapling claim with airdrop nullifier {}. Provide --message or --messages entry",
-                    proof.airdrop_nullifier
-                )
-            })?;
-        let proof_hash = hash_sapling_proof(proof);
-        let digest = signature_digest(
-            Pool::Sapling,
-            target_id.as_bytes(),
-            &proof_hash,
-            &message_hash,
-        )?;
-
-        let keys = sapling_keys
-            .as_ref()
-            .context("Sapling signing key should be initialized")?;
-        let spend_auth_sig = sapling::sign_claim(proof, secret, keys, &digest)?;
-        sapling.push(SaplingSignedClaim {
-            zkproof: proof.zkproof,
-            rk: proof.rk,
-            cv: proof.cv,
-            cv_sha256: proof.cv_sha256,
-            airdrop_nullifier: proof.airdrop_nullifier,
-            proof_hash,
-            message_hash,
-            spend_auth_sig,
-        });
-    }
-
-    let mut orchard_secret_by_nf = BTreeMap::new();
-    for secret in secrets.orchard {
-        let existing = orchard_secret_by_nf.insert(secret.airdrop_nullifier, secret);
-        ensure!(
-            existing.is_none(),
-            "Duplicate Orchard secret entry for airdrop nullifier"
-        );
-    }
-
-    let mut orchard = Vec::with_capacity(proofs.orchard_proofs.len());
-    for proof in &proofs.orchard_proofs {
-        let secret = orchard_secret_by_nf
-            .get(&proof.airdrop_nullifier)
-            .context("Missing secret material for Orchard proof entry")?;
-        let target_id = orchard_target_id
-            .as_deref()
-            .context("Orchard target_id must be present for Orchard signing")?;
-        let message_hash = message_hashes
-            .orchard_hash(proof.airdrop_nullifier)
-            .with_context(|| {
-                format!(
-                    "No message provided for Orchard claim with airdrop nullifier {}. Provide --message or --messages entry",
-                    proof.airdrop_nullifier
-                )
-            })?;
-        let proof_hash = hash_orchard_proof(proof)?;
-        let digest = signature_digest(
-            Pool::Orchard,
-            target_id.as_bytes(),
-            &proof_hash,
-            &message_hash,
-        )?;
-
-        let key = orchard_key
-            .as_ref()
-            .context("Orchard signing key should be initialized")?;
-        let spend_auth_sig = orchard::sign_claim(proof, secret, key, &digest)?;
-        orchard.push(OrchardSignedClaim {
-            zkproof: proof.zkproof.clone(),
-            rk: proof.rk,
-            cv: proof.cv,
-            cv_sha256: proof.cv_sha256,
-            airdrop_nullifier: proof.airdrop_nullifier,
-            proof_hash,
-            message_hash,
-            spend_auth_sig,
-        });
-    }
-
-    let submission = ClaimSubmission { sapling, orchard };
+    let submission = sign_claim_submission_from_bytes(
+        proofs,
+        secrets,
+        seed.expose_secret(),
+        account_id,
+        &config,
+        &resolved,
+    )
+    .await
+    .context("Failed to sign submission")?;
 
     let json = serde_json::to_string_pretty(&submission)?;
     tokio::fs::write(&submission_output_file, json).await?;

--- a/crates/zair-sdk/src/commands/key.rs
+++ b/crates/zair-sdk/src/commands/key.rs
@@ -6,9 +6,7 @@ use bip39::Language;
 use eyre::Context as _;
 use secrecy::{ExposeSecret as _, SecretBox, SecretString};
 use tracing::info;
-use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_protocol::consensus::Network;
-use zip32::AccountId;
 
 use super::sensitive_output::write_sensitive_output;
 use crate::seed::read_seed_file;
@@ -129,13 +127,9 @@ pub async fn key_derive_ufvk(
         read_seed_file(&seed_path).await?
     };
 
-    let account = AccountId::try_from(account).map_err(|_| eyre::eyre!("Invalid account-id"))?;
+    let ufvk = crate::api::key::derive_ufvk_from_seed(network, account, seed.expose_secret())?;
 
-    let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), account)
-        .map_err(|e| eyre::eyre!("Failed to derive spending key: {e:?}"))?;
-    let ufvk = usk.to_unified_full_viewing_key();
-
-    let text = format!("{}\n", ufvk.encode(&network));
+    let text = format!("{ufvk}\n");
     write_sensitive_output(&output, &text).await?;
     info!(file = ?output, "UFVK written");
     Ok(())

--- a/crates/zair-sdk/src/commands/nullifier_uniqueness.rs
+++ b/crates/zair-sdk/src/commands/nullifier_uniqueness.rs
@@ -9,7 +9,7 @@ use zair_core::base::Nullifier;
 ///
 /// # Errors
 /// Returns an error when a duplicate nullifier is found.
-pub(super) fn ensure_unique_airdrop_nullifiers<I>(nullifiers: I, context: &str) -> eyre::Result<()>
+pub fn ensure_unique_airdrop_nullifiers<I>(nullifiers: I, context: &str) -> eyre::Result<()>
 where
     I: IntoIterator<Item = Nullifier>,
 {

--- a/crates/zair-sdk/src/commands/orchard_params.rs
+++ b/crates/zair-sdk/src/commands/orchard_params.rs
@@ -27,7 +27,7 @@ fn tmp_path(path: &Path) -> PathBuf {
     path.with_file_name(format!("{file_name}.tmp.{}", std::process::id()))
 }
 
-fn read_params(bytes: Vec<u8>) -> eyre::Result<Params<vesta::Affine>> {
+pub fn read_params(bytes: Vec<u8>) -> eyre::Result<Params<vesta::Affine>> {
     let mut cursor = Cursor::new(bytes);
     Params::<vesta::Affine>::read(&mut cursor).context("Failed to read Orchard params")
 }

--- a/crates/zair-sdk/src/commands/pool_processor.rs
+++ b/crates/zair-sdk/src/commands/pool_processor.rs
@@ -24,6 +24,7 @@ pub struct PoolClaimResult<P> {
 
 impl<P> PoolClaimResult<P> {
     /// Create an empty result for when a pool has no claims.
+    #[must_use]
     pub const fn empty() -> Self {
         Self { claims: Vec::new() }
     }
@@ -47,6 +48,10 @@ pub trait PoolProcessor {
 
     /// Collects note metadata from the visitor.
     /// Returns `None` if the viewing key is not available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if note collection fails.
     fn collect_notes(
         visitor: &AccountNotesVisitor,
         viewing_keys: &ViewingKeys,

--- a/crates/zair-sdk/src/commands/submission_messages.rs
+++ b/crates/zair-sdk/src/commands/submission_messages.rs
@@ -7,6 +7,8 @@ use eyre::{Context as _, ensure};
 use serde::{Deserialize, Serialize};
 use zair_core::base::{Nullifier, hash_message};
 
+use crate::api::sign::ResolvedMessageHashes;
+
 /// One per-claim message-file assignment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaimMessageAssignment {
@@ -25,34 +27,6 @@ pub struct ClaimMessagesFile {
     /// Orchard claim message assignments.
     #[serde(default)]
     pub orchard: Vec<ClaimMessageAssignment>,
-}
-
-/// Resolved message hashes for submission sign/verify.
-#[derive(Debug, Clone, Default)]
-pub struct ResolvedMessageHashes {
-    shared: Option<[u8; 32]>,
-    sapling: BTreeMap<Nullifier, [u8; 32]>,
-    orchard: BTreeMap<Nullifier, [u8; 32]>,
-}
-
-impl ResolvedMessageHashes {
-    /// Resolve Sapling message hash for a given nullifier.
-    #[must_use]
-    pub fn sapling_hash(&self, nullifier: Nullifier) -> Option<[u8; 32]> {
-        self.sapling
-            .get(&nullifier)
-            .copied()
-            .or_else(|| self.shared.as_ref().copied())
-    }
-
-    /// Resolve Orchard message hash for a given nullifier.
-    #[must_use]
-    pub fn orchard_hash(&self, nullifier: Nullifier) -> Option<[u8; 32]> {
-        self.orchard
-            .get(&nullifier)
-            .copied()
-            .or_else(|| self.shared.as_ref().copied())
-    }
 }
 
 async fn load_assignment_hashes(

--- a/crates/zair-sdk/src/lib.rs
+++ b/crates/zair-sdk/src/lib.rs
@@ -1,7 +1,20 @@
 //! ZAIR SDK/workflow library.
 
+pub mod api;
 pub mod commands;
 pub mod common;
 pub mod network_params;
 
 mod seed;
+
+/// Installs the default rustls crypto provider (ring).
+/// Must be called before any TLS connections (e.g., `LightWalletd::connect`).
+///
+/// # Errors
+///
+/// Returns an error if a crypto provider has already been installed.
+pub fn install_default_crypto_provider() -> eyre::Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|e| eyre::eyre!("Failed to install rustls crypto provider: {e:?}"))
+}


### PR DESCRIPTION
Introduces a new module to the SDK that works without file-based I/O, more suitable for direct ZAIR claim submission integration for downstream consumers. 

Changes:
- New file-free API surface with functions for each claim step and a `run` function for the full flow.
- Replaced `eyre` with concrete error variants.
- Refactored commands to be file-based wrappers around the new API.
- Fixed a few misc clippy issues that were either explicitly allowed previously or ignored.