### PR TITLE
dep: bump to address vulnerabilities

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,4 +2,5 @@
 ignore = [
   # Awaiting upstream dependency update (zcash_client_backend)
   "RUSTSEC-2026-0009",
+  "RUSTSEC-2026-0105",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
  "halo2_proofs",
  "lazy_static",
  "pasta_curves",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sinsemilla",
  "subtle",
  "uint",
@@ -1877,7 +1877,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -1908,7 +1908,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
  "subtle",
 ]
@@ -2145,9 +2145,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2463,7 +2463,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "memuse",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "redjubjub",
  "subtle",
@@ -3807,7 +3807,7 @@ dependencies = [
  "halo2_proofs",
  "orchard",
  "pasta_curves",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "zair-core",
 ]
@@ -3821,7 +3821,7 @@ dependencies = [
  "halo2_proofs",
  "orchard",
  "pasta_curves",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zair-core",
  "zair-orchard-circuit",
@@ -3851,7 +3851,7 @@ dependencies = [
  "group",
  "incrementalmerkletree",
  "jubjub",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redjubjub",
  "sapling-crypto",
  "thiserror 2.0.18",
@@ -3873,7 +3873,7 @@ dependencies = [
  "http",
  "incrementalmerkletree",
  "orchard",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sapling-crypto",
  "schemars 1.2.1",
  "serde",
@@ -4070,7 +4070,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "redjubjub",
  "ripemd 0.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
- Bump `rand` to address [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097)
- Bump `rustls-webpki` to address [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104)